### PR TITLE
Comfyroll_ApplyControlNetStack Fix

### DIFF
--- a/Comfyroll_Nodes.py
+++ b/Comfyroll_Nodes.py
@@ -1163,6 +1163,7 @@ class Comfyroll_ApplyControlNetStack:
     @classmethod
     def INPUT_TYPES(s):
         return {"required": {"base_positive": ("CONDITIONING", ),
+                             "base_negative": ("CONDITIONING",),
                              "switch": ([
                                 "Off",
                                 "On"],),
@@ -1170,15 +1171,15 @@ class Comfyroll_ApplyControlNetStack:
                             }
         }                    
 
-    RETURN_TYPES = ("CONDITIONING", )
-    RETURN_NAMES = ("base_pos", )
+    RETURN_TYPES = ("CONDITIONING", "CONDITIONING", )
+    RETURN_NAMES = ("base_pos", "base_neg", )
     FUNCTION = "apply_controlnet_stack"
     CATEGORY = "Comfyroll/Conditioning"
 
-    def apply_controlnet_stack(self, base_positive, switch, controlnet_stack=None,):
+    def apply_controlnet_stack(self, base_positive, base_negative, switch, controlnet_stack=None,):
 
         if switch == "Off":
-            return (base_positive, )
+            return (base_positive, base_negative, )
     
         if controlnet_stack is not None:
             for controlnet_tuple in controlnet_stack:
@@ -1190,11 +1191,13 @@ class Comfyroll_ApplyControlNetStack:
                 else:
                     controlnet = controlnet_name
                 
-                base_positive = ControlNetApplyAdvanced().apply_controlnet(base_positive, controlnet, image, strength,
-                                                                   start_percent, end_percent)[0]
+                controlnet_conditioning = ControlNetApplyAdvanced().apply_controlnet(base_positive, base_negative,
+                                                                                     controlnet, image, strength,
+                                                                                     start_percent, end_percent)
 
-        return (base_positive,)
+                base_positive, base_negative = controlnet_conditioning[0], controlnet_conditioning[1]
 
+        return (base_positive, base_negative, )
 
 #---------------------------------------------------------------------------------------------------------------------------------------------------#
 


### PR DESCRIPTION
In order to properly use the base '**ControlNetApplyAdvanced**' class in the '**Comfyroll_ApplyControlNetStack**' , both the positive and negative conditionings must be fed to the class. I made the mistake in my commit of not  not including the negative conditioning.

Below is the results with this commits changes:
![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/d6844fe1-3f3d-4a6e-8645-745b9b672eec)
![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/eef2cdc2-e855-464f-bad1-525c09ddd888)

__________________________________________________

I would like to also add that I originally had the wrong idea that Comfy's '**ControlNetApplyAdvanced**' node's output conditionings were independent of each other, but in fact they are not. See below results with me giving a dummy negative just to make node's input requirements happy (but then not using the negative conditioning output)

![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/3f3b5803-5dc7-4349-81a8-f25d79fb5a94)
![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/daa332df-0287-4fee-92f0-b13b0f2456d6)

__________________________________________________

And below is the standard ControlNetApply behavior (which correctly matches my first example above)
![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/80bd40ac-ca4c-4a04-8387-d95f3f3478bd)
![image](https://github.com/RockOfFire/ComfyUI_Comfyroll_CustomNodes/assets/112517630/c4500f31-1001-4a49-ad08-4e00bfd6deb3)
__________________________________________________


Conclusion: In order to use the extra features provided by Comfy's '**ControlNetApplyAdvanced**' class, both positive and negative conditionings must be fed.