### PR TITLE
Fixed duplicate RETURN_TYPES def

### DIFF
--- a/nodes/conversion.py
+++ b/nodes/conversion.py
@@ -71,7 +71,6 @@ class CR_StringToCombo:
             },
         }
 
-    RETURN_TYPES = (any, "STRING", )
     RETURN_TYPES = ("any", "show_help", )
     FUNCTION = "convert"
     CATEGORY = icons.get("Comfyroll/Utils/Conversion")


### PR DESCRIPTION
Duplicate RETURN_TYPE overwrote previous declaration in nodes/conversion.py:

74:  RETURN_TYPES = (any, "STRING", )
75:  RETURN_TYPES = ("any", "show_help", )

invalidating the any output as string "any" instead of AnyType("*") '  

removed 75 for this pull.  